### PR TITLE
Рассчитывать начальные значения при загрузке страницы

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 			Моя еда стоила
 			<span id="food" contenteditable="true">400</span>₽, со скидкой в
 			<span id="food__discount" contenteditable="true">30</span>% это получается
-			<span id="food__total" class="total">280</span>₽.
+			<span id="food__total" class="total"></span>₽.
 			<div id="soup" class="soup disabled">
 				<label>
 					<input type="checkbox" id="food__soup" name="food__soup" value="130" />
@@ -20,7 +20,7 @@
 				<span class="only-when-enabled">
 					за <span id="food__soup-price" contenteditable="true">130</span>₽.
 					К сожалению, без скидки.
-					Вместе с ним <span id="food__with-soup-total" class="total">280</span>₽.
+					Вместе с ним <span id="food__with-soup-total" class="total"></span>₽.
 				</span>
 			</div>
 		</section>
@@ -28,16 +28,16 @@
 			Я выпил на
 			<span id="drink" contenteditable="true">200</span>₽,
 			а со скидкой в <span id="drink__discount" contenteditable="true">20</span>%
-			это уже <span class="total" id="drink__total">160</span>₽.
+			это уже <span class="total" id="drink__total"></span>₽.
 		</section>
 		<section class="tips">
 			Все вместе мы выпили и поели на
 			<span id="people__total" contenteditable="true">2000</span>₽,
 			и мы оставили <span id="tips" contenteditable="true">200</span>₽ чаевых.
-			Выходит, c меня <span id="tips__total" class="total">50</span>₽.
+			Выходит, c меня <span id="tips__total" class="total"></span>₽.
 		</section>
 		<section>
-			Итого, я должен <span class="total" id="total">510</span>₽.
+			Итого, я должен <span class="total" id="total"></span>₽.
 		</section>
 		<script src="./script.js"></script>
 		<!-- CSS-only GitHub ribbon: https://github.com/simonwhitaker/github-fork-ribbon-css -->

--- a/script.js
+++ b/script.js
@@ -67,6 +67,7 @@
 	}
 
 	foodSoupEl.addEventListener('change', toggleSoup);
+	window.addEventListener('load', calculateTotal);
 	document.body.addEventListener('keyup', calculateTotal);
 	document.body.addEventListener('click', calculateTotal);
 	document.body.addEventListener('keypress', (e) => {


### PR DESCRIPTION
Чтобы избежать дублирования данных (чтобы изменить процент скидки, приходилось менять два числа — см. комменты к #11 ).
Из-за этого есть минорный баг — при открытии отображается неправильное значение, но по клику в любое место всё пересчитывается (например, "Выходит, с меня *XX*" в расчете чаевых)